### PR TITLE
update Atmosphere-libs

### DIFF
--- a/sys-botbase/Makefile
+++ b/sys-botbase/Makefile
@@ -27,7 +27,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lnx -lm -lstratosphere
+LIBS	:= -lm -lstratosphere -lnx
 
 LIBDIRS	:= $(PORTLIBS) $(LIBNX) $(CURDIR)/../Atmosphere-libs/libstratosphere $(CURDIR)/../Atmosphere-libs/libvapours
 


### PR DESCRIPTION
this pull-request is in reference to issue #12 
wherin i have updated Atmosphere-libs to the same version used by 10.5 and fixed the makefile so that linking will correctly occur.