### PR TITLE
Screen on/off, single-command sequential button presses, sys info requests, token cancels + 12.0.0 support

### DIFF
--- a/sys-botbase/source/.vscode/settings.json
+++ b/sys-botbase/source/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.associations": {
-        "switch.h": "c"
+        "switch.h": "c",
+        "cstring": "c"
     }
 }

--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -317,3 +317,33 @@ void key(HiddbgKeyboardAutoPilotState* states, u64 sequentialCount)
 
     hiddbgUnsetKeyboardAutoPilotState();
 }
+
+void clickSequence(char* seq)
+{
+    char delim = ',';
+    char startWait = 'W';
+    char* command = strtok(seq, &delim);
+    HidControllerKeys currKey = {0};
+    u64 currentWait = 0;
+
+    initController();
+    while (command != NULL)
+    {
+        if (!strncmp(command, &startWait, 1))
+        {
+            // wait
+            currentWait = parseStringToInt(&command[1]);
+            svcSleepThread(currentWait * 1e+6l);
+        }
+        else
+        {
+            currKey = parseStringToButton(command);
+            press(currKey);
+            svcSleepThread(buttonClickSleepTime * 1e+6L);
+            release(currKey);
+        }
+
+        command = strtok(NULL, &delim);
+    }
+    
+}

--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -11,7 +11,7 @@
 bool bControllerIsInitialised = false;
 HiddbgHdlsHandle controllerHandle = {0};
 HiddbgHdlsDeviceInfo controllerDevice = {0};
-HiddbgHdlsStateV12 controllerState = {0};
+HiddbgHdlsState controllerState = {0};
 
 //Keyboard:
 HiddbgKeyboardAutoPilotState dummyKeyboardState = {0};
@@ -200,7 +200,7 @@ void press(HidNpadButton btn)
 {
     initController();
     controllerState.buttons |= btn;
-    Result rc = hiddbgSetHdlsStateV12Unsafe(controllerHandle, &controllerState);
+    Result rc = hiddbgSetHdlsState(controllerHandle, &controllerState);
     if (R_FAILED(rc) && debugResultCodes)
         printf("hiddbgSetHdlsState: %d\n", rc);
 }
@@ -209,7 +209,7 @@ void release(HidNpadButton btn)
 {
     initController();
     controllerState.buttons &= ~btn;
-    Result rc = hiddbgSetHdlsStateV12Unsafe(controllerHandle, &controllerState);
+    Result rc = hiddbgSetHdlsState(controllerHandle, &controllerState);
     if (R_FAILED(rc) && debugResultCodes)
         printf("hiddbgSetHdlsState: %d\n", rc);
 }
@@ -227,7 +227,7 @@ void setStickState(int side, int dxVal, int dyVal)
 		controllerState.analog_stick_r.x = dxVal;
 		controllerState.analog_stick_r.y = dyVal;
 	}
-    hiddbgSetHdlsStateV12Unsafe(controllerHandle, &controllerState);
+    hiddbgSetHdlsState(controllerHandle, &controllerState);
 }
 
 void reverseArray(u8* arr, int start, int end)

--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -318,7 +318,7 @@ void key(HiddbgKeyboardAutoPilotState* states, u64 sequentialCount)
     hiddbgUnsetKeyboardAutoPilotState();
 }
 
-void clickSequence(char* seq)
+void clickSequence(char* seq, u8* token)
 {
     char delim = ',';
     char startWait = 'W';
@@ -329,6 +329,9 @@ void clickSequence(char* seq)
     initController();
     while (command != NULL)
     {
+        if ((*token) == 1)
+            break;
+            
         if (!strncmp(command, &startWait, 1))
         {
             // wait

--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -348,5 +348,4 @@ void clickSequence(char* seq, u8* token)
 
         command = strtok(NULL, &delim);
     }
-    
 }

--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -320,8 +320,10 @@ void key(HiddbgKeyboardAutoPilotState* states, u64 sequentialCount)
 
 void clickSequence(char* seq, u8* token)
 {
-    char delim = ',';
-    char startWait = 'W';
+    const char delim = ',';
+    const char startWait = 'W';
+    const char startPress = '+';
+    const char startRelease = '-';
     char* command = strtok(seq, &delim);
     HidControllerKeys currKey = {0};
     u64 currentWait = 0;
@@ -331,8 +333,20 @@ void clickSequence(char* seq, u8* token)
     {
         if ((*token) == 1)
             break;
-            
-        if (!strncmp(command, &startWait, 1))
+
+        if (!strncmp(command, &startPress, 1))
+        {
+            // press
+            currKey = parseStringToButton(&command[1]);
+            press(currKey);
+        }  
+        if (!strncmp(command, &startRelease, 1))
+        {
+            // release
+            currKey = parseStringToButton(&command[1]);
+            press(currKey);
+        }   
+        else if (!strncmp(command, &startWait, 1))
         {
             // wait
             currentWait = parseStringToInt(&command[1]);

--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -340,20 +340,28 @@ void clickSequence(char* seq, u8* token)
         {
             // l stick
             s64 x = parseStringToSignedLong(&command[1]);
+            if(x > JOYSTICK_MAX) x = JOYSTICK_MAX; 
+            if(x < JOYSTICK_MIN) x = JOYSTICK_MIN; 
             s64 y = 0;
             command = strtok(NULL, &delim);
             if (command != NULL)
                 y = parseStringToSignedLong(command);
+            if(y > JOYSTICK_MAX) y = JOYSTICK_MAX;
+            if(y < JOYSTICK_MIN) y = JOYSTICK_MIN;
             setStickState(JOYSTICK_LEFT, (s32)x, (s32)y);
         }
         else if (!strncmp(command, &startRStick, 1))
         {
             // r stick
             s64 x = parseStringToSignedLong(&command[1]);
+            if(x > JOYSTICK_MAX) x = JOYSTICK_MAX; 
+            if(x < JOYSTICK_MIN) x = JOYSTICK_MIN; 
             s64 y = 0;
             command = strtok(NULL, &delim);
             if (command != NULL)
                 y = parseStringToSignedLong(command);
+            if(y > JOYSTICK_MAX) y = JOYSTICK_MAX;
+            if(y < JOYSTICK_MIN) y = JOYSTICK_MIN;
             setStickState(JOYSTICK_RIGHT, (s32)x, (s32)y);
         }
         else if (!strncmp(command, &startPress, 1))

--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -261,7 +261,7 @@ u64 followMainPointer(s64* jumps, size_t count)
     return offset;
 }
 
-void touch(HidTouchState* state, u64 sequentialCount, u64 holdTime, bool hold)
+void touch(HidTouchState* state, u64 sequentialCount, u64 holdTime, bool hold, u8* token)
 {
     initController();
     state->delta_time = holdTime; // only the first touch needs this for whatever reason
@@ -274,6 +274,9 @@ void touch(HidTouchState* state, u64 sequentialCount, u64 holdTime, bool hold)
             hiddbgSetTouchScreenAutoPilotState(NULL, 0);
             svcSleepThread(pollRate * 1e+6L);
         }
+
+        if ((*token) == 1)
+            break;
     }
 
     if(hold) // send finger release event

--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -320,10 +320,12 @@ void key(HiddbgKeyboardAutoPilotState* states, u64 sequentialCount)
 
 void clickSequence(char* seq, u8* token)
 {
-    const char delim = ',';
+    const char delim = ','; // used for chars and sticks
     const char startWait = 'W';
     const char startPress = '+';
     const char startRelease = '-';
+    const char startLStick = '%';
+    const char startRStick = '&';
     char* command = strtok(seq, &delim);
     HidControllerKeys currKey = {0};
     u64 currentWait = 0;
@@ -334,13 +336,33 @@ void clickSequence(char* seq, u8* token)
         if ((*token) == 1)
             break;
 
-        if (!strncmp(command, &startPress, 1))
+        if (!strncmp(command, &startLStick, 1))
+        {
+            // l stick
+            s64 x = parseStringToSignedLong(&command[1]);
+            s64 y = 0;
+            command = strtok(NULL, &delim);
+            if (command != NULL)
+                y = parseStringToSignedLong(command);
+            setStickState(JOYSTICK_LEFT, (s32)x, (s32)y);
+        }
+        else if (!strncmp(command, &startRStick, 1))
+        {
+            // r stick
+            s64 x = parseStringToSignedLong(&command[1]);
+            s64 y = 0;
+            command = strtok(NULL, &delim);
+            if (command != NULL)
+                y = parseStringToSignedLong(command);
+            setStickState(JOYSTICK_RIGHT, (s32)x, (s32)y);
+        }
+        else if (!strncmp(command, &startPress, 1))
         {
             // press
             currKey = parseStringToButton(&command[1]);
             press(currKey);
         }  
-        if (!strncmp(command, &startRelease, 1))
+        else if (!strncmp(command, &startRelease, 1))
         {
             // release
             currKey = parseStringToButton(&command[1]);
@@ -354,6 +376,7 @@ void clickSequence(char* seq, u8* token)
         }
         else
         {
+            // click
             currKey = parseStringToButton(command);
             press(currKey);
             svcSleepThread(buttonClickSleepTime * 1e+6L);

--- a/sys-botbase/source/commands.h
+++ b/sys-botbase/source/commands.h
@@ -50,5 +50,5 @@ void release(HidControllerKeys btn);
 void setStickState(int side, int dxVal, int dyVal);
 void reverseArray(u8* arr, int start, int end);
 u64 followMainPointer(s64* jumps, size_t count);
-void touch(HidTouchState* state, u64 sequentialCount, u64 holdTime, bool hold);
+void touch(HidTouchState* state, u64 sequentialCount, u64 holdTime, bool hold, u8* token);
 void key(HiddbgKeyboardAutoPilotState* states, u64 sequentialCount);

--- a/sys-botbase/source/commands.h
+++ b/sys-botbase/source/commands.h
@@ -52,3 +52,4 @@ void reverseArray(u8* arr, int start, int end);
 u64 followMainPointer(s64* jumps, size_t count);
 void touch(HidTouchState* state, u64 sequentialCount, u64 holdTime, bool hold, u8* token);
 void key(HiddbgKeyboardAutoPilotState* states, u64 sequentialCount);
+void clickSequence(char* seq);

--- a/sys-botbase/source/commands.h
+++ b/sys-botbase/source/commands.h
@@ -52,4 +52,4 @@ void reverseArray(u8* arr, int start, int end);
 u64 followMainPointer(s64* jumps, size_t count);
 void touch(HidTouchState* state, u64 sequentialCount, u64 holdTime, bool hold, u8* token);
 void key(HiddbgKeyboardAutoPilotState* states, u64 sequentialCount);
-void clickSequence(char* seq);
+void clickSequence(char* seq, u8* token);

--- a/sys-botbase/source/commands.h
+++ b/sys-botbase/source/commands.h
@@ -4,7 +4,7 @@ extern Handle debughandle;
 extern bool bControllerIsInitialised;
 extern HiddbgHdlsHandle controllerHandle;
 extern HiddbgHdlsDeviceInfo controllerDevice;
-extern HiddbgHdlsStateV12 controllerState;
+extern HiddbgHdlsState controllerState;
 extern HiddbgKeyboardAutoPilotState dummyKeyboardState;
 extern u64 buttonClickSleepTime;
 extern u64 keyPressSleepTime;

--- a/sys-botbase/source/commands.h
+++ b/sys-botbase/source/commands.h
@@ -4,7 +4,7 @@ extern Handle debughandle;
 extern bool bControllerIsInitialised;
 extern HiddbgHdlsHandle controllerHandle;
 extern HiddbgHdlsDeviceInfo controllerDevice;
-extern HiddbgHdlsState controllerState;
+extern HiddbgHdlsStateV12 controllerState;
 extern HiddbgKeyboardAutoPilotState dummyKeyboardState;
 extern u64 buttonClickSleepTime;
 extern u64 keyPressSleepTime;
@@ -32,6 +32,9 @@ typedef struct {
     u8 state;
 } KeyData;
 
+#define JOYSTICK_LEFT 0
+#define JOYSTICK_RIGHT 1
+
 void attach();
 void detach();
 u64 getMainNsoBase(u64 pid);
@@ -44,9 +47,9 @@ void poke(u64 offset, u64 size, u8* val);
 void writeMem(u64 offset, u64 size, u8* val);
 void peek(u64 offset, u64 size);
 void readMem(u8* out, u64 offset, u64 size);
-void click(HidControllerKeys btn);
-void press(HidControllerKeys btn);
-void release(HidControllerKeys btn);
+void click(HidNpadButton btn);
+void press(HidNpadButton btn);
+void release(HidNpadButton btn);
 void setStickState(int side, int dxVal, int dyVal);
 void reverseArray(u8* arr, int start, int end);
 u64 followMainPointer(s64* jumps, size_t count);

--- a/sys-botbase/source/main.c
+++ b/sys-botbase/source/main.c
@@ -250,7 +250,7 @@ int argmain(int argc, char **argv)
     {
         if(argc != 2)
             return 0;
-        HidControllerKeys key = parseStringToButton(argv[1]);
+        HidNpadButton key = parseStringToButton(argv[1]);
         click(key);
     }
 
@@ -275,7 +275,7 @@ int argmain(int argc, char **argv)
     {
         if(argc != 2)
             return 0;
-        HidControllerKeys key = parseStringToButton(argv[1]);
+        HidNpadButton key = parseStringToButton(argv[1]);
         press(key);
     }
 
@@ -284,7 +284,7 @@ int argmain(int argc, char **argv)
     {
         if(argc != 2)
             return 0;
-        HidControllerKeys key = parseStringToButton(argv[1]);
+        HidNpadButton key = parseStringToButton(argv[1]);
         release(key);
     }
 

--- a/sys-botbase/source/main.c
+++ b/sys-botbase/source/main.c
@@ -682,6 +682,13 @@ int argmain(int argc, char **argv)
             viCloseDisplay(&temp_display);
         }
     }
+    
+    if (!strcmp(argv[0], "charge"))
+	{
+        u32 charge;
+        psmGetBatteryChargePercentage(&charge);
+        printf("%d\n", charge);
+    }
 
     return 0;
 }

--- a/sys-botbase/source/main.c
+++ b/sys-botbase/source/main.c
@@ -254,7 +254,8 @@ int argmain(int argc, char **argv)
         click(key);
     }
 
-    //clickSeq <sequence> eg clickSeq A,W1000,B,W200,DUP,W500,DD,W350 (some params don't parse correctly, such as DDOWN so use the alt)
+    //clickSeq <sequence> eg clickSeq A,W1000,B,W200,DUP,W500,DD,W350,%5000,1500,W2650,%0,0 (some params don't parse correctly, such as DDOWN so use the alt)
+    //syntax: <button>=click, 'W<number>'=wait/sleep thread, '+<button>'=press button, '-<button>'=release button, '%<x axis>,<y axis>'=move L stick <x axis, y axis>, '&<x axis>,<y axis>'=move R stick <x axis, y axis> 
     if (!strcmp(argv[0], "clickSeq"))
     {
         if(argc != 2)

--- a/sys-botbase/source/main.c
+++ b/sys-botbase/source/main.c
@@ -415,7 +415,7 @@ int argmain(int argc, char **argv)
     }
 
     if(!strcmp(argv[0], "getVersion")){
-        printf("1.71\n");
+        printf("1.72\n");
     }
 	
 	// follow pointers and print absolute offset (little endian, flip it yourself if required)
@@ -642,6 +642,24 @@ int argmain(int argc, char **argv)
         }
 
         makeKeys(keystate, 1);
+    }
+
+    //turns off the screen (display)
+    if (!strcmp(argv[0], "screenOff"))
+	{
+        ViDisplay temp_display;
+        Result rc = viOpenDefaultDisplay(&temp_display);
+        if (R_SUCCEEDED(rc))
+            viSetDisplayPowerState(&temp_display, ViPowerState_Off);
+    }
+
+    //turns on the screen (display)
+    if (!strcmp(argv[0], "screenOn"))
+	{
+        ViDisplay temp_display;
+        Result rc = viOpenDefaultDisplay(&temp_display);
+        if (R_SUCCEEDED(rc))
+            viSetDisplayPowerState(&temp_display, ViPowerState_On);
     }
 
     return 0;

--- a/sys-botbase/source/main.c
+++ b/sys-botbase/source/main.c
@@ -421,7 +421,7 @@ int argmain(int argc, char **argv)
     }
 
     if(!strcmp(argv[0], "getVersion")){
-        printf("1.73\n");
+        printf("1.8\n");
     }
 	
 	// follow pointers and print absolute offset (little endian, flip it yourself if required)

--- a/sys-botbase/source/main.c
+++ b/sys-botbase/source/main.c
@@ -760,6 +760,8 @@ int main()
     rc = threadCreate(&clickThread, sub_click, (void*)currentClick, NULL, THREAD_SIZE, 0x2C, -2); 
     if (R_SUCCEEDED(rc))
         {rc = threadStart(&clickThread);} // curly brackets remove compiler warning
+    
+	flashLed();
 
     while (appletMainLoop())
     {

--- a/sys-botbase/source/main.c
+++ b/sys-botbase/source/main.c
@@ -110,9 +110,6 @@ void __appInit(void)
     rc = psmInitialize();
     if (R_FAILED(rc))
         fatalThrow(rc);
-    rc = hidsysInitialize();
-    if (R_FAILED(rc))
-        fatalThrow(rc);
 }
 
 void __appExit(void)
@@ -125,7 +122,6 @@ void __appExit(void)
     socketExit();
     viExit();
     psmExit();
-    hidsysExit();
 }
 
 u64 mainLoopSleepTime = 50;

--- a/sys-botbase/source/main.c
+++ b/sys-botbase/source/main.c
@@ -657,7 +657,9 @@ int argmain(int argc, char **argv)
     if (!strcmp(argv[0], "screenOff"))
 	{
         ViDisplay temp_display;
-        Result rc = viOpenDefaultDisplay(&temp_display);
+        Result rc = viOpenDisplay("Internal", &temp_display);
+        if (R_FAILED(rc))
+            rc = viOpenDefaultDisplay(&temp_display);
         if (R_SUCCEEDED(rc))
         {
             rc = viSetDisplayPowerState(&temp_display, ViPowerState_NotScanning); // not scanning keeps the screen on but does not push new pixels to the display. Battery save is non-negligible and should be used where possible
@@ -670,7 +672,9 @@ int argmain(int argc, char **argv)
     if (!strcmp(argv[0], "screenOn"))
 	{
         ViDisplay temp_display;
-        Result rc = viOpenDefaultDisplay(&temp_display);
+        Result rc = viOpenDisplay("Internal", &temp_display);
+        if (R_FAILED(rc))
+            rc = viOpenDefaultDisplay(&temp_display);
         if (R_SUCCEEDED(rc))
         {
             rc = viSetDisplayPowerState(&temp_display, ViPowerState_On);

--- a/sys-botbase/source/util.c
+++ b/sys-botbase/source/util.c
@@ -224,5 +224,9 @@ static void sendPatternStatic(const HidsysNotificationLedPattern* pattern)
 
 void flashLed()
 {
+    Result rc = hidsysInitialize();
+    if (R_FAILED(rc))
+        fatalThrow(rc);
     sendPatternStatic(&breathingpattern);
+    hidsysExit();
 }

--- a/sys-botbase/source/util.c
+++ b/sys-botbase/source/util.c
@@ -160,7 +160,7 @@ HidControllerKeys parseStringToButton(char* arg)
     {
         return KEY_DRIGHT;
     }
-    else if (strcmp(arg, "DDOWN") == 0)
+    else if (strcmp(arg, "DDOWN") == 0 || strcmp(arg, "DD") == 0)
     {
         return KEY_DDOWN;
     }

--- a/sys-botbase/source/util.c
+++ b/sys-botbase/source/util.c
@@ -170,15 +170,15 @@ HidNpadButton parseStringToButton(char* arg)
     {
         return HidNpadButton_Minus;
     }
-    else if (strcmp(arg, "DLEFT") == 0)
+    else if (strcmp(arg, "DLEFT") == 0 || strcmp(arg, "DL") == 0)
     {
         return HidNpadButton_Left;
     }
-    else if (strcmp(arg, "DUP") == 0)
+    else if (strcmp(arg, "DUP") == 0 || strcmp(arg, "DU") == 0)
     {
         return HidNpadButton_Up;
     }
-    else if (strcmp(arg, "DRIGHT") == 0)
+    else if (strcmp(arg, "DRIGHT") == 0 || strcmp(arg, "DR") == 0)
     {
         return HidNpadButton_Right;
     }

--- a/sys-botbase/source/util.c
+++ b/sys-botbase/source/util.c
@@ -120,81 +120,82 @@ u8* parseStringToByteBuffer(char* arg, u64* size)
     return buffer;
 }
 
-HidControllerKeys parseStringToButton(char* arg)
+HidNpadButton parseStringToButton(char* arg)
 {
     if (strcmp(arg, "A") == 0)
     {
-        return KEY_A;
+        return HidNpadButton_A;
     } 
     else if (strcmp(arg, "B") == 0)
     {
-        return KEY_B;
+        return HidNpadButton_B;
     }
     else if (strcmp(arg, "X") == 0)
     {
-        return KEY_X;
+        return HidNpadButton_X;
     }
     else if (strcmp(arg, "Y") == 0)
     {
-        return KEY_Y;
+        return HidNpadButton_Y;
     }
     else if (strcmp(arg, "RSTICK") == 0)
     {
-        return KEY_RSTICK;
+        return HidNpadButton_StickR;
     }
     else if (strcmp(arg, "LSTICK") == 0)
     {
-        return KEY_LSTICK;
+        return HidNpadButton_StickL;
     }
     else if (strcmp(arg, "L") == 0)
     {
-        return KEY_L;
+        return HidNpadButton_L;
     }
     else if (strcmp(arg, "R") == 0)
     {
-        return KEY_R;
+        return HidNpadButton_R;
     }
     else if (strcmp(arg, "ZL") == 0)
     {
-        return KEY_ZL;
+        return HidNpadButton_ZL;
     }
     else if (strcmp(arg, "ZR") == 0)
     {
-        return KEY_ZR;
+        return HidNpadButton_ZR;
     }
     else if (strcmp(arg, "PLUS") == 0)
     {
-        return KEY_PLUS;
+        return HidNpadButton_Plus;
     }
     else if (strcmp(arg, "MINUS") == 0)
     {
-        return KEY_MINUS;
+        return HidNpadButton_Minus;
     }
     else if (strcmp(arg, "DLEFT") == 0)
     {
-        return KEY_DLEFT;
+        return HidNpadButton_Left;
     }
     else if (strcmp(arg, "DUP") == 0)
     {
-        return KEY_DUP;
+        return HidNpadButton_Up;
     }
     else if (strcmp(arg, "DRIGHT") == 0)
     {
-        return KEY_DRIGHT;
+        return HidNpadButton_Right;
     }
     else if (strcmp(arg, "DDOWN") == 0 || strcmp(arg, "DD") == 0)
     {
-        return KEY_DDOWN;
+        return HidNpadButton_Down;
     }
     else if (strcmp(arg, "HOME") == 0)
     {
-        return KEY_HOME;
+        return HiddbgNpadButton_Home;
     }
     else if (strcmp(arg, "CAPTURE") == 0)
     {
-        return KEY_CAPTURE;
+        return HiddbgNpadButton_Capture;
     }
-    return KEY_A; //I guess lol
+    
+    return HidNpadButton_A; //I guess lol
 }
 
 Result capsscCaptureForDebug(void *buffer, size_t buffer_size, u64 *size) {

--- a/sys-botbase/source/util.h
+++ b/sys-botbase/source/util.h
@@ -10,3 +10,4 @@ s64 parseStringToSignedLong(char* arg);
 u8* parseStringToByteBuffer(char* arg, u64* size);
 HidControllerKeys parseStringToButton(char* arg);
 Result capsscCaptureForDebug(void *buffer, size_t buffer_size, u64 *size); //big thanks to Behemoth from the Reswitched Discord!
+void flashLed(void);

--- a/sys-botbase/source/util.h
+++ b/sys-botbase/source/util.h
@@ -8,6 +8,6 @@ int setupServerSocket();
 u64 parseStringToInt(char* arg);
 s64 parseStringToSignedLong(char* arg);
 u8* parseStringToByteBuffer(char* arg, u64* size);
-HidControllerKeys parseStringToButton(char* arg);
+HidNpadButton parseStringToButton(char* arg);
 Result capsscCaptureForDebug(void *buffer, size_t buffer_size, u64 *size); //big thanks to Behemoth from the Reswitched Discord!
 void flashLed(void);


### PR DESCRIPTION
I wanted to add a few QoL/power save things. None of this will be extremely fleshed out because of how close we are to tma being usable (even if it's still a few months out or not)

Biggest things with this version (1.8?) will be the screen stop-scanning commands and sending an entire button sequence at once (for the sake of some functions that simply aren't reliable over network) and probably whatever else small QoL changes might be useful for 24/7 no-intervention bots.