### PR TITLE
Fix clickSeq release button not registering

### DIFF
--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -487,7 +487,7 @@ void clickSequence(char* seq, u8* token)
         {
             // release
             currKey = parseStringToButton(&command[1]);
-            press(currKey);
+            release(currKey);
         }   
         else if (!strncmp(command, &startWait, 1))
         {


### PR DESCRIPTION
Previously the ``-<button>`` command in a clickSeq would start holding the button instead of releasing it, functioning identically to ``+<button>``. This PR just changes that one line to call ``release`` instead of ``press``.