### PR TITLE
Print '\n' for failed reads

### DIFF
--- a/sys-botbase/source/commands.c
+++ b/sys-botbase/source/commands.c
@@ -248,6 +248,7 @@ void peek(u64 offset, u64 size)
     Result rc = readMem(out, offset, size);
     if (R_FAILED(rc))
     {
+        printf("\n");
         detach();
         free(out);
         return;
@@ -278,6 +279,7 @@ void peekInfinite(u64 offset, u64 size)
         Result rc = readMem(out, offset + totalFetched, thisBuffersize);
         if (R_FAILED(rc))
         {
+            printf("\n");
             detach();
             free(out);
             return;
@@ -309,6 +311,7 @@ void peekMulti(u64* offset, u64* size, u64 count)
         Result rc = readMem(out + ofs, offset[i], size[i]);
         if (R_FAILED(rc))
         {
+            printf("\n");
             detach();
             free(out);
             return;


### PR DESCRIPTION
Forgot that the Peek* commands use `\n` as a terminator, so we need this if the read failed.